### PR TITLE
Add @justfixnyc/util package

### DIFF
--- a/packages/geosearch-requester/package.json
+++ b/packages/geosearch-requester/package.json
@@ -12,14 +12,15 @@
     "access": "public"
   },
   "devDependencies": {
+    "@justfixnyc/util": "*",
     "concurrently": "^5.0.0",
     "rollup": "^1.23.1",
+    "rollup-plugin-node-resolve": "^5.2.0",
     "typescript": "3.6.4"
   },
   "scripts": {
     "prepublish": "yarn build",
-    "build-manual-test": "rollup test-manual/geosearch-manual-test.js --format iife --file test-manual/geosearch-manual-test.bundle.js --sourcemap inline",
-    "build": "tsc && yarn build-manual-test",
-    "watch": "concurrently --kill-others \"tsc --watch\" \"yarn build-manual-test --watch\""
+    "build": "tsc && rollup -c",
+    "watch": "concurrently --kill-others \"tsc --watch --preserveWatchOutput\" \"rollup -c --watch\""
   }
 }

--- a/packages/geosearch-requester/rollup.config.ts
+++ b/packages/geosearch-requester/rollup.config.ts
@@ -1,0 +1,19 @@
+import resolve from 'rollup-plugin-node-resolve';
+import { RollupWatchOptions } from 'rollup';
+
+const config: RollupWatchOptions = {
+  input: 'test-manual/geosearch-manual-test.js',
+  output: {
+    format: 'iife',
+    file: 'test-manual/geosearch-manual-test.bundle.js',
+    sourcemap: 'inline',
+  },
+  watch: {
+    clearScreen: false
+  },
+  plugins: [
+    resolve()
+  ]
+};
+
+export default config;

--- a/packages/geosearch-requester/test-manual/geosearch-manual-test.ts
+++ b/packages/geosearch-requester/test-manual/geosearch-manual-test.ts
@@ -1,8 +1,10 @@
 import { GeoSearchRequester } from "../geosearch-requester";
 
-const inputEl = document.getElementsByTagName('input')[0];
-const resultsEl = document.getElementsByTagName('ol')[0];
-const logEl = document.getElementsByTagName('pre')[0];
+import { getHTMLElement } from "@justfixnyc/util";
+
+const inputEl = getHTMLElement('input', '#input');
+const resultsEl = getHTMLElement('ol', '#results');
+const logEl = getHTMLElement('pre', '#log');
 
 function log(msg: string, level: 'info'|'error' = 'info') {
   const item = document.createElement('div');

--- a/packages/geosearch-requester/test-manual/index.html
+++ b/packages/geosearch-requester/test-manual/index.html
@@ -5,8 +5,8 @@
 <label for="input">Search text</label>
 <input type="text" id="input">
 <h2>GeoSearch results</h2>
-<ol></ol>
+<ol id="results"></ol>
 <h2>Log</h2>
-<pre></pre>
+<pre id="log"></pre>
 <p><strong>NOTE:</strong> This page will only work on modern browsers and is intended for testing that the core logic of <code>GeoSearchRequester</code> works, not that it works on older browsers (polyfills and transpilers will be needed for the latter).</p>
 <script src="geosearch-manual-test.bundle.js"></script>

--- a/packages/util/CHANGELOG.md
+++ b/packages/util/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+## 0.0.1 (2019-10-13)
+
+Initial release.

--- a/packages/util/CONTRIBUTING.md
+++ b/packages/util/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+Make sure you read the [README for this monorepo](../../README.md).

--- a/packages/util/LICENSE
+++ b/packages/util/LICENSE
@@ -1,0 +1,24 @@
+@justfixnyc/util
+
+Copyright (c) JustFix.nyc. All rights reserved.
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/util/README.md
+++ b/packages/util/README.md
@@ -1,0 +1,3 @@
+This module provides miscellaneous **dependency-free** utilities.
+
+See the individual `.ts` files in the repository for full documentation.

--- a/packages/util/get-html-element.ts
+++ b/packages/util/get-html-element.ts
@@ -1,0 +1,20 @@
+/**
+ * Find an element with the given HTML tag and selector, raising an exception
+ * if it's not found.
+ * 
+ * @param tagName The name of the element's HTML tag.
+ * @param selector The selector for the element, not including its HTML tag.
+ * @param parent The parent node to search within (defaults to `document`).
+ */
+export function getHTMLElement<K extends keyof HTMLElementTagNameMap>(
+  tagName: K,
+  selector: string,
+  parent: ParentNode = document
+): HTMLElementTagNameMap[K] {
+  const finalSelector = `${tagName}${selector}`;
+  const node = parent.querySelector(finalSelector);
+  if (!node) {
+    throw new Error(`Couldn't find any elements matching "${finalSelector}"`);
+  }
+  return node as HTMLElementTagNameMap[K];
+}

--- a/packages/util/index.ts
+++ b/packages/util/index.ts
@@ -1,0 +1,1 @@
+export { getHTMLElement } from './get-html-element';

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@justfixnyc/util",
+  "version": "0.0.0",
+  "main": "index.js",
+  "types": "index.d.ts",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/justfixnyc/justfix-ts/tree/master/packages/util"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "typescript": "3.6.4"
+  },
+  "scripts": {
+    "prepublish": "yarn build",
+    "build": "tsc",
+    "watch": "tsc --watch"
+  }
+}

--- a/packages/util/tsconfig.json
+++ b/packages/util/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,7 +39,7 @@
     // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
 
     /* Module Resolution Options */
-    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -831,6 +831,13 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.12.tgz#7c6c571cc2f3f3ac4a59a5f2bd48f5bdbc8653cc"
   integrity sha512-KPYGmfD0/b1eXurQ59fXD1GBzhSQfz6/lKBxkaHX9dKTzjXbK68Zt7yGUxUsCS1jeTy/8aL+d9JEr+S54mpkWQ==
 
+"@types/resolve@0.0.8":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-0.0.8.tgz#f26074d238e02659e323ce1a13d041eee280e194"
+  integrity sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
+  dependencies:
+    "@types/node" "*"
+
 "@zkochan/cmd-shim@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@zkochan/cmd-shim/-/cmd-shim-3.1.0.tgz#2ab8ed81f5bb5452a85f25758eb9b8681982fd2e"
@@ -1113,6 +1120,11 @@ buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"
   integrity sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
+
+builtin-modules@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-3.1.0.tgz#aad97c15131eb76b65b50ef208e7584cd76a7484"
+  integrity sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==
 
 builtins@^1.0.3:
   version "1.0.3"
@@ -1793,6 +1805,11 @@ esprima@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
+
+estree-walker@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.1.tgz#53049143f40c6eb918b23671d1fe3219f3a1b362"
+  integrity sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==
 
 eventemitter3@^3.1.0:
   version "3.1.2"
@@ -2560,6 +2577,11 @@ is-glob@^4.0.0, is-glob@^4.0.1:
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
   dependencies:
     is-extglob "^2.1.1"
+
+is-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-module/-/is-module-1.0.0.tgz#3258fb69f78c14d5b815d664336b4cffb6441591"
+  integrity sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=
 
 is-number@^3.0.0:
   version "3.0.0"
@@ -3995,7 +4017,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.10.0:
+resolve@^1.10.0, resolve@^1.11.1:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
   integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
@@ -4026,6 +4048,24 @@ rimraf@2, rimraf@^2.5.4, rimraf@^2.6.2, rimraf@^2.6.3:
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
   dependencies:
     glob "^7.1.3"
+
+rollup-plugin-node-resolve@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-5.2.0.tgz#730f93d10ed202473b1fb54a5997a7db8c6d8523"
+  integrity sha512-jUlyaDXts7TW2CqQ4GaO5VJ4PwwaV8VUGA7+km3n6k6xtOEacf61u0VXwN80phY/evMcaS+9eIeJ9MOyDxt5Zw==
+  dependencies:
+    "@types/resolve" "0.0.8"
+    builtin-modules "^3.1.0"
+    is-module "^1.0.0"
+    resolve "^1.11.1"
+    rollup-pluginutils "^2.8.1"
+
+rollup-pluginutils@^2.8.1:
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz#72f2af0748b592364dbd3389e600e5a9444a351e"
+  integrity sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==
+  dependencies:
+    estree-walker "^0.6.1"
 
 rollup@^1.23.1:
   version "1.23.1"


### PR DESCRIPTION
This adds a `@justfixnyc/util` package with a single function, `getHTMLElement()`, which I lifted from my [`webgl-fun2`](https://github.com/toolness/webgl-fun2/blob/master/src/get-element.ts) repo.

It then uses this package in `@justfixnyc/geosearch-requester`'s manual test.
