### PR TITLE
Updated Spanish link in Moratorium Banner

### DIFF
--- a/packages/react-common/src/moratorium-banner.tsx
+++ b/packages/react-common/src/moratorium-banner.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 
-/** 
- * Renders a banner of text announcing JustFix's status during COVID-19 and details of the NYC Eviction Moratorium. 
- * The optional "locale" property is used for localization. If the property is set to an accepted locale (like "es"), 
- * the resulting blurb of text will be rendered in that given language. If the property is undefined or not an accepted 
+/**
+ * Renders a banner of text announcing JustFix's status during COVID-19 and details of the NYC Eviction Moratorium.
+ * The optional "locale" property is used for localization. If the property is set to an accepted locale (like "es"),
+ * the resulting blurb of text will be rendered in that given language. If the property is undefined or not an accepted
  * locale, the English version of the blurb is returned.
- * 
+ *
  * Note: the component is completely unstyled, i.e. styling it is the responsibility of the caller.
-*/
+ */
 export const CovidMoratoriumBanner: React.FC<{ locale?: string }> = ({
   locale,
 }) => {
@@ -21,7 +21,7 @@ export const CovidMoratoriumBanner: React.FC<{ locale?: string }> = ({
       inquilinos, los inquilinos no pueden ser desalojados por ninguna razón
       hasta el 1 de octubre. Visita las{" "}
       <a
-        href="https://www.righttocounselnyc.org/moratoria_de_desalojo"
+        href="https://docs.google.com/document/d/1uzT1lduZAzNLpy_WxSOU1oSOTOPs0YrWekzLd8o6tAs"
         target="_blank"
         rel="noopener noreferrer"
       >


### PR DESCRIPTION
This hotfix updates the outbound link for the Spanish version of our `CovidMoratoriumBanner component`. For some reason, RTC is creating a separate resource for the most up to date information in Spanish.