### PR TITLE
Add custom GeoSearch Autocomplete url option

### DIFF
--- a/packages/geosearch-requester/CHANGELOG.md
+++ b/packages/geosearch-requester/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.2.0 (2020-09-03)
+
+* Added a new optional constructor parameter called `customGeoAutocompleteUrl`.
+
 ## 0.1.0 (2020-04-16)
 
 * Factored out a `SearchRequester` class which can be adapted to use

--- a/packages/geosearch-requester/src/geosearch-requester.test.ts
+++ b/packages/geosearch-requester/src/geosearch-requester.test.ts
@@ -1,17 +1,38 @@
 import { GeoSearchRequester, GeoSearchRequesterOptions } from "./index";
 
-function makeOpts(opts?: Partial<GeoSearchRequesterOptions>): GeoSearchRequesterOptions {
+function makeOpts(
+  opts?: Partial<GeoSearchRequesterOptions>,
+): GeoSearchRequesterOptions {
   return {
     fetch: jest.fn(),
     onError: jest.fn(),
     onResults: jest.fn(),
-    ...opts
+    ...opts,
   };
 }
 
 describe("GeoSearchRequester", () => {
   it("throws an error when fetch implementation doesn't exist", () => {
-    expect(() => new GeoSearchRequester(makeOpts({fetch: undefined})))
-      .toThrow(/A fetch implementation was not passed to GeoSearchRequester, and one does not exist in the global scope/i);
+    expect(
+      () => new GeoSearchRequester(makeOpts({ fetch: undefined })),
+    ).toThrow(
+      /A fetch implementation was not passed to GeoSearchRequester, and one does not exist in the global scope/i,
+    );
+  });
+  it("allows for custom GeoAutocomplete urls to be passed in", () => {
+    var r = new GeoSearchRequester(
+      makeOpts({
+        customGeoAutocompleteUrl: "https://www.boop.com/autocomplete",
+      }),
+    );
+    expect(r.searchQueryToURL("Boopy Boop")).toBe(
+      "https://www.boop.com/autocomplete?text=Boopy%20Boop",
+    );
+  });
+  it("uses the standard GeoAutocomplete url when no custom one is defined", () => {
+    var r = new GeoSearchRequester(makeOpts());
+    expect(r.searchQueryToURL("Boopy Boop")).toBe(
+      "https://geosearch.planninglabs.nyc/v1/autocomplete?text=Boopy%20Boop",
+    );
   });
 });

--- a/packages/geosearch-requester/src/geosearch-requester.test.ts
+++ b/packages/geosearch-requester/src/geosearch-requester.test.ts
@@ -1,38 +1,25 @@
 import { GeoSearchRequester, GeoSearchRequesterOptions } from "./index";
 
-function makeOpts(
-  opts?: Partial<GeoSearchRequesterOptions>,
-): GeoSearchRequesterOptions {
+function makeOpts(opts?: Partial<GeoSearchRequesterOptions>): GeoSearchRequesterOptions {
   return {
     fetch: jest.fn(),
     onError: jest.fn(),
     onResults: jest.fn(),
-    ...opts,
+    ...opts
   };
 }
 
 describe("GeoSearchRequester", () => {
   it("throws an error when fetch implementation doesn't exist", () => {
-    expect(
-      () => new GeoSearchRequester(makeOpts({ fetch: undefined })),
-    ).toThrow(
-      /A fetch implementation was not passed to GeoSearchRequester, and one does not exist in the global scope/i,
-    );
+    expect(() => new GeoSearchRequester(makeOpts({fetch: undefined})))
+      .toThrow(/A fetch implementation was not passed to GeoSearchRequester, and one does not exist in the global scope/i);
   });
   it("allows for custom GeoAutocomplete urls to be passed in", () => {
-    var r = new GeoSearchRequester(
-      makeOpts({
-        customGeoAutocompleteUrl: "https://www.boop.com/autocomplete",
-      }),
-    );
-    expect(r.searchQueryToURL("Boopy Boop")).toBe(
-      "https://www.boop.com/autocomplete?text=Boopy%20Boop",
-    );
+    var r = new GeoSearchRequester(makeOpts({customGeoAutocompleteUrl: "https://www.boop.com/autocomplete"}));
+    expect(r.searchQueryToURL("Boopy Boop")).toBe("https://www.boop.com/autocomplete?text=Boopy%20Boop");
   });
   it("uses the standard GeoAutocomplete url when no custom one is defined", () => {
     var r = new GeoSearchRequester(makeOpts());
-    expect(r.searchQueryToURL("Boopy Boop")).toBe(
-      "https://geosearch.planninglabs.nyc/v1/autocomplete?text=Boopy%20Boop",
-    );
+    expect(r.searchQueryToURL("Boopy Boop")).toBe("https://geosearch.planninglabs.nyc/v1/autocomplete?text=Boopy%20Boop");
   });
 });

--- a/packages/geosearch-requester/src/geosearch-requester.ts
+++ b/packages/geosearch-requester/src/geosearch-requester.ts
@@ -1,34 +1,42 @@
 import { SearchRequester, SearchRequesterOptions } from "./search-requester";
 
-export {
-  SearchHttpStatusError as GeoSearchHttpStatusError,
-} from "./search-requester";
+export { SearchHttpStatusError as GeoSearchHttpStatusError } from "./search-requester";
 
-export type GeoSearchRequesterOptions = SearchRequesterOptions<GeoSearchResults>;
+export type GeoSearchRequesterOptions = SearchRequesterOptions<
+  GeoSearchResults
+> & {
+  /**
+   * (Optional)
+   * A custom base url for GeoAutocomplete endpoint, like `https://www.boop.com/v1/autocomplete`.
+   * If not defined, the standard NYC Planning Labs GeoSearch Autocomplete url is used.
+   */
+  customGeoAutocompleteUrl?: string;
+};
 
 /**
  * For documentation about this endpoint, see:
  *
  * https://geosearch.planninglabs.nyc/docs/#autocomplete
  */
-export const GEO_AUTOCOMPLETE_URL = 'https://geosearch.planninglabs.nyc/v1/autocomplete';
+export const GEO_AUTOCOMPLETE_URL =
+  "https://geosearch.planninglabs.nyc/v1/autocomplete";
 
 /**
  * The keys here were obtained experimentally, I'm not actually sure
  * if/where they are formally specified.
  */
 export enum GeoSearchBoroughGid {
-  Manhattan = 'whosonfirst:borough:1',
-  Bronx = 'whosonfirst:borough:2',
-  Brooklyn = 'whosonfirst:borough:3',
-  Queens = 'whosonfirst:borough:4',
-  StatenIsland = 'whosonfirst:borough:5',
+  Manhattan = "whosonfirst:borough:1",
+  Bronx = "whosonfirst:borough:2",
+  Brooklyn = "whosonfirst:borough:3",
+  Queens = "whosonfirst:borough:4",
+  StatenIsland = "whosonfirst:borough:5",
 }
 
 /**
  * This is what the NYC Geosearch API returns from its
  * autocomplete endpoint.
- * 
+ *
  * Note that some of the fields are "unknown", which
  * just implies that they exist but we're not really
  * sure what type they are (nor do we particularly
@@ -41,7 +49,7 @@ export interface GeoSearchResults {
 
 export interface GeoSearchFeature {
   geometry: unknown;
-  properties: GeoSearchProperties
+  properties: GeoSearchProperties;
 }
 
 /**
@@ -80,7 +88,12 @@ export interface GeoSearchProperties {
  * due to e.g. keyboard input.
  */
 export class GeoSearchRequester extends SearchRequester<GeoSearchResults> {
+  constructor(readonly options: GeoSearchRequesterOptions) {
+    super(options);
+  }
   searchQueryToURL(query: string): string {
-    return `${GEO_AUTOCOMPLETE_URL}?text=${encodeURIComponent(query)}`;
+    return `${
+      this.options.customGeoAutocompleteUrl || GEO_AUTOCOMPLETE_URL
+    }?text=${encodeURIComponent(query)}`;
   }
 }

--- a/packages/geosearch-requester/src/geosearch-requester.ts
+++ b/packages/geosearch-requester/src/geosearch-requester.ts
@@ -19,18 +19,18 @@ export type GeoSearchRequesterOptions = SearchRequesterOptions<
  * https://geosearch.planninglabs.nyc/docs/#autocomplete
  */
 export const GEO_AUTOCOMPLETE_URL =
-  "https://geosearch.planninglabs.nyc/v1/autocomplete";
+  'https://geosearch.planninglabs.nyc/v1/autocomplete';
 
 /**
  * The keys here were obtained experimentally, I'm not actually sure
  * if/where they are formally specified.
  */
 export enum GeoSearchBoroughGid {
-  Manhattan = "whosonfirst:borough:1",
-  Bronx = "whosonfirst:borough:2",
-  Brooklyn = "whosonfirst:borough:3",
-  Queens = "whosonfirst:borough:4",
-  StatenIsland = "whosonfirst:borough:5",
+  Manhattan = 'whosonfirst:borough:1',
+  Bronx = 'whosonfirst:borough:2',
+  Brooklyn = 'whosonfirst:borough:3',
+  Queens = 'whosonfirst:borough:4',
+  StatenIsland = 'whosonfirst:borough:5',
 }
 
 /**


### PR DESCRIPTION
This PR adds a new optional constructor parameter called `customGeoAutocompleteUrl` to our GeoSearchRequester class. This allows the user to override the standard NYC Planning Labs Autocomplete url, which will let us try out our own hosted GeoSearch tool!