### PR TITLE
Add `postalcode` property, `geoSearch()` function.

### DIFF
--- a/packages/geosearch-requester/CHANGELOG.md
+++ b/packages/geosearch-requester/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.3.0 (2020-09-11)
+
+* Exposed the `postalcode` property for `GeoSearchResults`.
+* Added a convenience `geoSearch()` function.
+
 ## 0.2.0 (2020-09-03)
 
 * Added a new optional constructor parameter called `customGeoAutocompleteUrl`.

--- a/packages/geosearch-requester/src/geosearch-requester.ts
+++ b/packages/geosearch-requester/src/geosearch-requester.ts
@@ -80,6 +80,13 @@ export interface GeoSearchProperties {
    * property, e.g. "3002920026".
    */
   pad_bbl: string;
+
+  /**
+   * The zip code, e.g. "11201". Note that in extremely rare
+   * cases, this is undefined, such as (at the time of this writing)
+   * for "276 M L K Boulevard, Manhattan".
+   */
+  postalcode: string | undefined;
 }
 
 /**

--- a/packages/geosearch-requester/src/geosearch-requester.ts
+++ b/packages/geosearch-requester/src/geosearch-requester.ts
@@ -104,3 +104,26 @@ export class GeoSearchRequester extends SearchRequester<GeoSearchResults> {
     }?text=${encodeURIComponent(query)}`;
   }
 }
+
+/**
+ * A convenience function for making NYC Planning Labs GeoSearch
+ * requests outside the context of an autocomplete UI: provide
+ * an address, and this function will return results.
+ */
+export function geoSearch(
+  address: string,
+  options?: Omit<
+    GeoSearchRequesterOptions,
+    "onError" | "onResults" | "throttleMs"
+  >
+): Promise<GeoSearchResults> {
+  return new Promise((resolve, reject) => {
+    const req = new GeoSearchRequester({
+      ...options,
+      onError: reject,
+      onResults: resolve,
+      throttleMs: 0,
+    });
+    req.changeSearchRequest(address);
+  });
+}


### PR DESCRIPTION
This exposes the `postalcode` property for `GeoSearchResults` and also adds a convenience `geoSearch()` function to the `@justfixnyc/geosearch-requester` package.