### PR TITLE
Remove "En Ingles" flag from Moratorium banner

### DIFF
--- a/packages/react-common/src/moratorium-banner.tsx
+++ b/packages/react-common/src/moratorium-banner.tsx
@@ -24,7 +24,7 @@ export const CovidMoratoriumBanner: React.FC<{ locale?: string }> = ({
         target="_blank"
         rel="noopener noreferrer"
       >
-        Coalición del Derecho a Representación Legal (en inglés)
+        Coalición del Derecho a Representación Legal
       </a>{" "}
       para obtener más información.
     </>


### PR DESCRIPTION
This PR removes an unneeded snippet of Spanish text from our `CovidMoratoriumBanner` component, as we now have a Spanish outbound link to include.