### PR TITLE
Add CommonJS versions of some packages.

### DIFF
--- a/packages/geosearch-requester/CHANGELOG.md
+++ b/packages/geosearch-requester/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.4.0 (2020-11-25)
+
+Add CommonJS module support.
+
 ## 0.3.1 (2020-09-11)
 
 * Make this module work in Node, hopefully.

--- a/packages/geosearch-requester/README.md
+++ b/packages/geosearch-requester/README.md
@@ -1,7 +1,10 @@
-This module provides the base functionality for building autocomplete
+This package provides the base functionality for building autocomplete
 interfaces powered by the [NYC Planning Labs GeoSearch API][geosearch].
 
 For an example of this package in use, see the [manual test][] code.
+
+If you don't have a transpiler or module bundler, a CommonJS version
+of this package can be found under `commonjs`.
 
 [geosearch]: https://geosearch.planninglabs.nyc/
 [manual test]: test-manual/geosearch-manual-test.ts

--- a/packages/geosearch-requester/commonjs/package.json
+++ b/packages/geosearch-requester/commonjs/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts"
+}

--- a/packages/geosearch-requester/package.json
+++ b/packages/geosearch-requester/package.json
@@ -27,7 +27,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "prepublish": "yarn build",
-    "build": "tsc && rollup -c",
+    "build": "tsc && tsc --build tsconfig.commonjs.json && rollup -c",
     "watch": "concurrently --kill-others \"tsc --watch --preserveWatchOutput\" \"rollup -c --watch\""
   }
 }

--- a/packages/geosearch-requester/tsconfig.commonjs.json
+++ b/packages/geosearch-requester/tsconfig.commonjs.json
@@ -1,0 +1,9 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+      "outDir": "./commonjs/dist",
+      "target": "es2015",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
+      "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+  }
+}
+  

--- a/packages/util/CHANGELOG.md
+++ b/packages/util/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.2.0 (2020-11-25)
+
+Add CommonJS module support.
+
 ## 0.1.0 (2020-08-14)
 
 Added the assertion helpers `assertNotUndefined`, `assertNotNull`, and `hardFail`.

--- a/packages/util/README.md
+++ b/packages/util/README.md
@@ -1,3 +1,6 @@
 This module provides miscellaneous **dependency-free** utilities.
 
 See the individual `.ts` files in the repository for full documentation.
+
+If you don't have a transpiler or module bundler, a CommonJS version
+of this package can be found under `commonjs`.

--- a/packages/util/commonjs/package.json
+++ b/packages/util/commonjs/package.json
@@ -1,4 +1,4 @@
 {
-  "main": "dist/src/index.js",
-  "types": "dist/src/index.d.ts"
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts"
 }

--- a/packages/util/commonjs/package.json
+++ b/packages/util/commonjs/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts"
+}

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -23,7 +23,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "prepublish": "yarn build",
-    "build": "tsc",
+    "build": "tsc && tsc --build tsconfig.commonjs.json",
     "watch": "tsc --watch"
   }
 }

--- a/packages/util/tsconfig.commonjs.json
+++ b/packages/util/tsconfig.commonjs.json
@@ -1,0 +1,9 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+      "outDir": "./commonjs/dist",
+      "target": "es2015",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
+      "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+  }
+}
+  


### PR DESCRIPTION
This fixes #21 by adding CommonJS versions of the `util` and `geosearch-requester` packages, under the `commonjs` directory of each package.  We're only adding CommonJS versions of these for now because they can be used from non-browser environments where it's more likely for a transpiler/bundler to be absent.

This was made using strategies outlined in https://2ality.com/2019/10/hybrid-npm-packages.html.