### PR TITLE
Update banner with prettier after manual bump.

### DIFF
--- a/packages/react-common/src/moratorium-banner.tsx
+++ b/packages/react-common/src/moratorium-banner.tsx
@@ -32,7 +32,7 @@ export const CovidMoratoriumBanner: React.FC<{ locale?: string }> = ({
         target="_blank"
         rel="noopener noreferrer"
       >
-        Learn more here 
+        Learn more here
       </a>
     </>
   );


### PR DESCRIPTION
I previously manually added a space to the banner to force a bump (since the publishing got cut off by an inopportune storm that took my internet down and it got in a weird state where locally it seemed as though the change had ben made but lerna refused to push it to npm). This extra space made prettier fail.

This removes the space again.