### PR TITLE
Remove 'here' from learn more

### DIFF
--- a/packages/react-common/src/moratorium-banner.tsx
+++ b/packages/react-common/src/moratorium-banner.tsx
@@ -20,7 +20,7 @@ export const CovidMoratoriumBanner: React.FC<{ locale?: string }> = ({
         target="_blank"
         rel="noopener noreferrer"
       >
-        Más información aquí
+        Más información
       </a>
     </>
   ) : (
@@ -32,7 +32,7 @@ export const CovidMoratoriumBanner: React.FC<{ locale?: string }> = ({
         target="_blank"
         rel="noopener noreferrer"
       >
-        Learn more here
+        Learn more
       </a>
     </>
   );


### PR DESCRIPTION
Remove the word 'here' from the banner.