### PR TITLE
update to geosearch v2 & new response structure

### DIFF
--- a/packages/geosearch-requester/CHANGELOG.md
+++ b/packages/geosearch-requester/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## 1.0.0 (2022-11-29)
+
+* Switch from v1 to the new v2 endpoint, breaking change to results structure.
+* BBL property for `GeoSearchResults` changes from `pad_bbl` to `addendum.pad.bbl`
+
 ## 0.4.0 (2020-11-25)
 
 Add CommonJS module support.

--- a/packages/geosearch-requester/src/geosearch-requester.test.ts
+++ b/packages/geosearch-requester/src/geosearch-requester.test.ts
@@ -32,7 +32,7 @@ describe("GeoSearchRequester", () => {
   it("uses the standard GeoAutocomplete url when no custom one is defined", () => {
     var r = new GeoSearchRequester(makeOpts());
     expect(r.searchQueryToURL("Boopy Boop")).toBe(
-      "https://geosearch.planninglabs.nyc/v1/autocomplete?text=Boopy%20Boop"
+      "https://geosearch.planninglabs.nyc/v2/autocomplete?text=Boopy%20Boop"
     );
   });
 });

--- a/packages/geosearch-requester/src/geosearch-requester.ts
+++ b/packages/geosearch-requester/src/geosearch-requester.ts
@@ -7,7 +7,7 @@ export type GeoSearchRequesterOptions = SearchRequesterOptions<
 > & {
   /**
    * (Optional)
-   * A custom base url for GeoAutocomplete endpoint, like `https://www.boop.com/v1/autocomplete`.
+   * A custom base url for GeoAutocomplete endpoint, like `https://www.boop.com/v2/autocomplete`.
    * If not defined, the standard NYC Planning Labs GeoSearch Autocomplete url is used.
    */
   customGeoAutocompleteUrl?: string;
@@ -17,20 +17,21 @@ export type GeoSearchRequesterOptions = SearchRequesterOptions<
  * For documentation about this endpoint, see:
  *
  * https://geosearch.planninglabs.nyc/docs/#autocomplete
+ *
  */
 export const GEO_AUTOCOMPLETE_URL =
-  "https://geosearch.planninglabs.nyc/v1/autocomplete";
+  "https://geosearch.planninglabs.nyc/v2/autocomplete";
 
 /**
  * The keys here were obtained experimentally, I'm not actually sure
  * if/where they are formally specified.
  */
 export enum GeoSearchBoroughGid {
-  Manhattan = "whosonfirst:borough:1",
-  Bronx = "whosonfirst:borough:2",
-  Brooklyn = "whosonfirst:borough:3",
-  Queens = "whosonfirst:borough:4",
-  StatenIsland = "whosonfirst:borough:5",
+  Manhattan = "whosonfirst:borough:421205771",
+  Bronx = "whosonfirst:borough:421205773",
+  Brooklyn = "whosonfirst:borough:421205765",
+  Queens = "whosonfirst:borough:421205767",
+  StatenIsland = "whosonfirst:borough:421205775",
 }
 
 /**
@@ -60,7 +61,7 @@ export interface GeoSearchProperties {
   /** e.g. "Brooklyn" */
   borough: string;
 
-  /** e.g. "whosonfirst:borough:2" */
+  /** e.g. "whosonfirst:borough:421205773" */
   borough_gid: GeoSearchBoroughGid;
 
   /** e.g. "150" */
@@ -79,7 +80,11 @@ export interface GeoSearchProperties {
    * The 10-digit padded Borough-Block-Lot (BBL) number for the
    * property, e.g. "3002920026".
    */
-  pad_bbl: string;
+  addendum: {
+    pad: {
+      bbl: string;
+    };
+  };
 
   /**
    * The zip code, e.g. "11201". Note that in extremely rare

--- a/packages/geosearch-requester/test-manual/geosearch-manual-test.ts
+++ b/packages/geosearch-requester/test-manual/geosearch-manual-test.ts
@@ -32,7 +32,7 @@ const gsr = new GeoSearchRequester({
     resultsEl.textContent = "";
     for (let { properties: props } of results.features) {
       const li = document.createElement("li");
-      li.textContent = `${props.name}, ${props.borough} (BBL ${props.pad_bbl})`;
+      li.textContent = `${props.name}, ${props.borough} (BBL ${props.addendum.pad.bbl})`;
       resultsEl.appendChild(li);
     }
   },


### PR DESCRIPTION
The Geosearch API is switching over to the new v2 endpoint and deprecating v1. We were notified of the change, with all the details of the relevant fields changed in the new response structure, in this [issue on wow](https://github.com/JustFixNYC/who-owns-what/issues/666).

This PR updates our ts package that we publish on NPM and use in WOW and tenants2. 

The main change is that the BBL property for `GeoSearchResults` changes from `pad_bbl` to `addendum.pad.bbl`

[sc-11187]