### PR TITLE
add storageFactory function to util package

### DIFF
--- a/packages/util/CHANGELOG.md
+++ b/packages/util/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.4.0 (2022-12-21)
+
+Add `storageFactory` function to help with avoid
+errors with localStorage and sessionStorage when 
+they aren't supported by the browser settings.
+
 ## 0.3.0 (2021-04-27)
 
 Add an optional custom message to assertion helpers `assertNotUndefined` and `assertNotNull`.

--- a/packages/util/index.ts
+++ b/packages/util/index.ts
@@ -1,2 +1,3 @@
 export { getHTMLElement } from "./get-html-element";
 export { assertNotNull, assertNotUndefined, hardFail } from "./assertions";
+export { storageFactory } from "./storage-factory";

--- a/packages/util/storage-factory.test.ts
+++ b/packages/util/storage-factory.test.ts
@@ -1,0 +1,62 @@
+import { storageFactory } from "./storage-factory";
+
+describe("storageFactory()", () => {
+  const localStore = storageFactory(() => localStorage);
+
+  beforeEach(() => {
+    localStore.clear();
+  });
+
+  it("knows if localStorage is supported", () => {
+    expect(localStore.isSupported()).toBe(true);
+
+    const localStorageMock = {
+      getItem: jest.fn(() => {
+        throw "localStorage not supported";
+      }),
+    };
+    Object.defineProperty(window, "localStorage", { value: localStorageMock });
+
+    expect(localStore.isSupported()).toBe(false);
+  });
+
+  it("sets and gets items", () => {
+    localStore.setItem("foo", "bar");
+    expect(localStore.getItem("foo")).toBe("bar");
+  });
+
+  it("gets key by index", () => {
+    localStore.setItem("foo", "bar");
+    expect(localStore.key(0)).toBe("foo");
+  });
+
+  it("gets storage length", () => {
+    expect(localStore.length).toBe(0);
+    localStore.setItem("foo", "bar");
+    expect(localStore.length).toBe(1);
+  });
+
+  it("removes items", () => {
+    localStore.setItem("foo", "bar");
+    expect(localStore.getItem("foo")).toBe("bar");
+    localStore.removeItem("foo");
+    expect(localStore.getItem("foo")).toBeNull();
+  });
+
+  it("clears items", () => {
+    localStore.setItem("foo", "bar");
+    expect(localStore.getItem("foo")).toBe("bar");
+    localStore.clear();
+    expect(localStore.getItem("foo")).toBeNull();
+  });
+
+  it("works with sessionStorage also", () => {
+    const sessionStore = storageFactory(() => sessionStorage);
+    sessionStore.setItem("foo", "bar");
+    try {
+      expect(sessionStore.getItem("foo")).toBe("bar");
+    } finally {
+      sessionStore.clear();
+    }
+  });
+});

--- a/packages/util/storage-factory.ts
+++ b/packages/util/storage-factory.ts
@@ -1,0 +1,79 @@
+/* ISC License (ISC). Copyright 2017 Michal Zalecki */
+// https://michalzalecki.com/why-using-localStorage-directly-is-a-bad-idea/
+
+export function storageFactory(getStorage: () => Storage): Storage {
+  let inMemoryStorage: { [key: string]: string } = {};
+
+  function isSupported() {
+    try {
+      const testKey = "__some_random_key_you_are_not_going_to_use__";
+      getStorage().setItem(testKey, testKey);
+      getStorage().removeItem(testKey);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
+  function clear(): void {
+    if (isSupported()) {
+      getStorage().clear();
+    } else {
+      inMemoryStorage = {};
+    }
+  }
+
+  function getItem(name: string): string | null {
+    if (isSupported()) {
+      return getStorage().getItem(name);
+    }
+    if (inMemoryStorage.hasOwnProperty(name)) {
+      return inMemoryStorage[name];
+    }
+    return null;
+  }
+
+  function key(index: number): string | null {
+    if (isSupported()) {
+      return getStorage().key(index);
+    } else {
+      return Object.keys(inMemoryStorage)[index] || null;
+    }
+  }
+
+  function removeItem(name: string): void {
+    if (isSupported()) {
+      getStorage().removeItem(name);
+    } else {
+      delete inMemoryStorage[name];
+    }
+  }
+
+  function setItem(name: string, value: string): void {
+    if (isSupported()) {
+      getStorage().setItem(name, value);
+    } else {
+      inMemoryStorage[name] = String(value); // not everyone uses TypeScript
+    }
+  }
+
+  function length(): number {
+    if (isSupported()) {
+      return getStorage().length;
+    } else {
+      return Object.keys(inMemoryStorage).length;
+    }
+  }
+
+  return {
+    isSupported,
+    getItem,
+    setItem,
+    removeItem,
+    clear,
+    key,
+    get length() {
+      return length();
+    },
+  };
+}


### PR DESCRIPTION
We were getting some errors form our use of localStorage on the org site.
[sc-10520]

I found this [helpful blog](https://michalzalecki.com/why-using-localStorage-directly-is-a-bad-idea/) that discusses some of those common issues and shares a good solution of using a `storageFactory` that wraps all the operations of local/session storage, but also handles the cases where localStorage isn't supported. 

This PR adds this function to the `util` package, so that we can use this across our tools. Right now org-site uses localStorage to keep the cookies-consent banner hidden once closed (JustFixNYC/justfix-website#234), and we'll need to do the same thing with sessionStorage for the wow big portfolios warning (JustFixNYC/who-owns-what#689).


