### PR TITLE
update typescript for util package to ^3.9.7

### DIFF
--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -17,7 +17,7 @@
     "@babel/preset-typescript": "7.6.0",
     "@types/jest": "24.0.15",
     "jest": "24.9.0",
-    "typescript": "^3.9.7"
+    "typescript": "3.9.10"
   },
   "scripts": {
     "test": "jest",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -17,7 +17,7 @@
     "@babel/preset-typescript": "7.6.0",
     "@types/jest": "24.0.15",
     "jest": "24.9.0",
-    "typescript": "3.6.4"
+    "typescript": "^3.9.7"
   },
   "scripts": {
     "test": "jest",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7832,6 +7832,11 @@ typescript@3.6.4:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.4.tgz#b18752bb3792bc1a0281335f7f6ebf1bbfc5b91d"
   integrity sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==
 
+typescript@^3.9.7:
+  version "3.9.10"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
+  integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
+
 uglify-js@^3.1.4:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.6.1.tgz#ae7688c50e1bdcf2f70a0e162410003cf9798311"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7832,7 +7832,7 @@ typescript@3.6.4:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.4.tgz#b18752bb3792bc1a0281335f7f6ebf1bbfc5b91d"
   integrity sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==
 
-typescript@^3.9.7:
+typescript@3.9.10:
   version "3.9.10"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
   integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==


### PR DESCRIPTION
There was an error when trying to publish the changes to utils that was coming from the jest-diff package and the version of typescript needed to be updated in dev-dependencies